### PR TITLE
Update train.sh

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -1,1 +1,1 @@
-python -m torch.distributed.launch --nproc_per_node=8 train.py --checkpoint ./pretrained_checkpoint/sam_vit_l_0b3195.pth --model-type vit_l --output work_dirs/pa_sam_l
+torchrun --nproc_per_node=8 train.py --checkpoint ./pretrained_checkpoint/sam_vit_l_0b3195.pth --model-type vit_l --output work_dirs/pa_sam_l


### PR DESCRIPTION
PyTorch error: unrecognized arguments: --local-rank=0 FutureWarning: The module torch.distributed.launch is deprecated and will be removed in future. Use torchrun.
Note that --use-env is set by default in torchrun